### PR TITLE
Add Rust CI workflow and update README for formatting and linting guidelines

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,38 @@
+name: Rust Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  rust:
+    name: Format, Clippy, Tests (story-core)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust (stable) with components
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry + build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-${{ runner.os }} # stable key across jobs
+
+      - name: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy (story-core)
+        run: cargo clippy -p story-core -- -D warnings
+
+      - name: cargo test (story-core)
+        run: cargo test -p story-core --all-features --verbose
+
+      - name: cargo doc (story-core)
+        run: RUSTDOCFLAGS="-D warnings" cargo doc -p story-core --no-deps
+
+  # Note: src-tauri clippy/build to be wired later as platform setup stabilizes.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Contributions are welcome!
 - Fork and PR for code changes.  
 - See [CONTRIBUTING.md](CONTRIBUTING.md).  
 
+### 🦀 Rust Formatting & Linting
+- Format check: `cargo fmt -- --check`
+- Lint (deny warnings): `cargo clippy -- -D warnings`
+
+Both commands should pass locally before opening a PR. See `CONTRIBUTING.md` for the full checklist.
+
 ---
 
 ## 📄 License

--- a/crates/story-core/src/runtime.rs
+++ b/crates/story-core/src/runtime.rs
@@ -39,7 +39,7 @@ impl StoryState {
         let node = self.current_node();
         node.choices
             .iter()
-            .filter(|c| c.cond.as_ref().map_or(true, |e| eval(&self.vars, e)))
+            .filter(|c| c.cond.as_ref().is_none_or(|e| eval(&self.vars, e)))
             .map(|c| ChoiceView {
                 text: c.text.clone(),
                 next: c.next.clone(),
@@ -52,7 +52,7 @@ impl StoryState {
         let avail: Vec<&StoryChoice> = node
             .choices
             .iter()
-            .filter(|c| c.cond.as_ref().map_or(true, |e| eval(&self.vars, e)))
+            .filter(|c| c.cond.as_ref().is_none_or(|e| eval(&self.vars, e)))
             .collect();
 
         if filtered_index >= avail.len() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# Rust formatting configuration
+# Using default rustfmt settings; file presence enables consistent formatting.


### PR DESCRIPTION
Introduce a continuous integration workflow for Rust that includes formatting checks, linting, and testing. Update the README to include guidelines for local formatting and linting before submitting pull requests.