### PR TITLE
feat: add story schema and sample

### DIFF
--- a/assets/samples/bunker.story.json
+++ b/assets/samples/bunker.story.json
@@ -1,0 +1,36 @@
+{
+  "variables": {
+    "geiger": 0
+  },
+  "start": "door",
+  "nodes": [
+    {
+      "id": "door",
+      "text": "You stand before the sealed bunker door.",
+      "choices": [
+        { "text": "Open the door", "next": "outside" },
+        { "text": "Go back to bed", "next": "bed" }
+      ]
+    },
+    {
+      "id": "outside",
+      "text": "A wasteland stretches out.",
+      "inc": { "geiger": 1 },
+      "choices": [
+        { "text": "Return inside", "next": "door" },
+        { "text": "Keep walking", "next": "end", "if": "geiger < 2" }
+      ]
+    },
+    {
+      "id": "bed",
+      "text": "You curl up on the bunker bunk and reset your radiation count.",
+      "set": { "geiger": 0 },
+      "end": true
+    },
+    {
+      "id": "end",
+      "text": "You wander into the wasteland and are never seen again.",
+      "end": true
+    }
+  ]
+}

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,51 @@
+# Story Schema
+
+This repository uses JSON files to describe interactive stories. The schema lives in `packages/schema/story.schema.json`.
+
+## Top-level structure
+
+A story document contains:
+
+- **`variables`** – object of initial variables keyed by name.
+- **`start`** – id of the starting node.
+- **`nodes`** – array of all story nodes.
+
+## Nodes
+
+Each entry in `nodes` describes a single state in the story:
+
+- `id` – unique identifier for the node.
+- `text` – narrative text displayed for the node.
+- `set` – optional object assigning variables to specific values.
+- `inc` – optional object incrementing numeric variables.
+- `choices` – array of choices presented to the reader.
+- `end` – optional boolean marking the node as terminal.
+
+### Choices
+
+Choices link nodes together.
+
+- `text` – label shown to the reader.
+- `next` – id of the node that follows when the choice is taken.
+- `if` – optional string expression. When it evaluates to `true` the choice is available.
+
+## Example
+
+```json
+{
+  "variables": { "geiger": 0 },
+  "start": "door",
+  "nodes": [
+    {
+      "id": "door",
+      "text": "You stand before the sealed bunker door.",
+      "choices": [
+        { "text": "Open the door", "next": "outside" },
+        { "text": "Go back to bed", "next": "bed" }
+      ]
+    }
+  ]
+}
+```
+
+See [`assets/samples/bunker.story.json`](../assets/samples/bunker.story.json) for a more complete example that validates against the schema.

--- a/packages/schema/story.schema.json
+++ b/packages/schema/story.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Skroll Story",
+  "description": "Schema for interactive stories used by the Skroll runtime.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "variables",
+    "start",
+    "nodes"
+  ],
+  "properties": {
+    "variables": {
+      "type": "object",
+      "description": "Initial story variables keyed by name.",
+      "additionalProperties": {
+        "type": [
+          "string",
+          "number",
+          "boolean"
+        ]
+      }
+    },
+    "start": {
+      "type": "string",
+      "description": "ID of the starting node."
+    },
+    "nodes": {
+      "type": "array",
+      "description": "All nodes that compose the story.",
+      "items": {
+        "$ref": "#/definitions/node"
+      }
+    }
+  },
+  "definitions": {
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "text"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "set": {
+          "type": "object",
+          "description": "Assign variables to specific values when entering the node.",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          }
+        },
+        "inc": {
+          "type": "object",
+          "description": "Increment numeric variables when entering the node.",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "choices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/choice"
+          }
+        },
+        "end": {
+          "type": "boolean",
+          "description": "Marks the node as terminal."
+        }
+      }
+    },
+    "choice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "text",
+        "next"
+      ],
+      "properties": {
+        "text": {
+          "type": "string"
+        },
+        "next": {
+          "type": "string"
+        },
+        "if": {
+          "type": "string",
+          "description": "Simple expression evaluated to determine if the choice is available."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add JSON schema for stories
- document schema and provide bunker story sample

## Testing
- `pnpm lint`
- `node --input-type=commonjs - <<'NODE' ...` (Ajv validation)


------
https://chatgpt.com/codex/tasks/task_e_68bc2aababb4832eb215114b8b684350