### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,4 +1,6 @@
 name: Frontend
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/abianche/skroll/security/code-scanning/2](https://github.com/abianche/skroll/security/code-scanning/2)

The fix is to add an explicit `permissions` key with the value `contents: read` to the workflow file. This ensures that the GitHub Actions' automatically generated `GITHUB_TOKEN` has only read-only access to repository contents during the job execution, which is the minimum necessary for checking out code and running build/lint/format steps. The best way to do this is to insert the following at the top level of the workflow YAML, after the `name` key and before the `on:` key, so it applies to every job unless otherwise specified. No modifications to workflow logic or functionality are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
