### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/abianche/skroll/security/code-scanning/1](https://github.com/abianche/skroll/security/code-scanning/1)

To address this issue, add an explicit `permissions` block to the workflow, limiting the `GITHUB_TOKEN` to only the minimum permissions needed. The best option is to add:

```yaml
permissions:
  contents: read
```

at the top level, just after the `name` key. This sets the default for all jobs in the workflow (including the shown `rust` job) to `contents: read`, significantly reducing the privilege level for the workflow runs. No other code changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
