### PR TITLE
Add skroll-lang compiler skeleton

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,19 @@
+name: Rust Checks
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo test --workspace --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
-members = ["crates/story-core", "src-tauri"]
+members = [
+    "crates/story-core",
+    "crates/skroll-schema",
+    "crates/skroll-lang",
+    "src-tauri"
+]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -8,9 +8,31 @@
 
 ---
 
+## 🦀 Rust Workspace Quickstart
+
+Scaffold for a branching-story toolchain.
+
+- `story-core`: runtime/IR types
+- `skroll-schema`: versioned JSON document types
+- `skroll-lang`: compiler front-end (parser/validator/emitter) + `skrollc` CLI
+
+```bash
+cargo build
+cargo run -p skroll-lang -- compile examples/hello.skr -o examples/hello.story.json
+```
+
+### Roadmap
+
+* Parser with spans (chumsky)
+* AST → IR (story-core)
+* JSON emission (skroll-schema)
+* Tree-sitter grammar for editor
+
+---
+
 ## ✨ Vision
-This project aims to provide writers and developers with a simple yet powerful editor for **interactive fiction**.  
-Think *Inklewriter* or *Twine*, but designed to run **everywhere**: desktop, mobile, and web.  
+This project aims to provide writers and developers with a simple yet powerful editor for **interactive fiction**.
+Think *Inklewriter* or *Twine*, but designed to run **everywhere**: desktop, mobile, and web.
 
 With this tool you can:
 - Write branching stories in a clean editor.

--- a/crates/skroll-lang/Cargo.toml
+++ b/crates/skroll-lang/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "skroll-lang"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chumsky = "0.9"
+thiserror = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+
+story-core = { path = "../story-core" }
+skroll-schema = { path = "../skroll-schema" }

--- a/crates/skroll-lang/src/bin/skrollc.rs
+++ b/crates/skroll-lang/src/bin/skrollc.rs
@@ -1,0 +1,57 @@
+use clap::{Parser, Subcommand};
+use skroll_lang::compile_to_document;
+use std::{fs, path::PathBuf};
+
+#[derive(Parser)]
+#[command(name = "skrollc", about = "Skroll compiler CLI")]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Compile a .skr source file into runtime JSON.
+    Compile {
+        /// Input .skr file
+        input: PathBuf,
+        /// Output JSON path (defaults to <input>.story.json)
+        #[arg(short, long)]
+        out: Option<PathBuf>,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.cmd {
+        Command::Compile { input, out } => {
+            let src = fs::read_to_string(&input)?;
+            match compile_to_document(&src) {
+                Ok(doc) => {
+                    let json = serde_json::to_string_pretty(&doc)?;
+                    let out_path = out.unwrap_or_else(|| {
+                        let mut p = input.clone();
+                        p.set_extension("story.json");
+                        p
+                    });
+                    fs::write(&out_path, json)?;
+                    eprintln!("Wrote {}", out_path.display());
+                    Ok(())
+                }
+                Err(diags) => {
+                    for d in diags {
+                        eprintln!(
+                            "error: {}{}",
+                            d.message,
+                            match d.span {
+                                Some(s) => format!(" ({}..{})", s.start, s.end),
+                                None => String::new(),
+                            }
+                        );
+                    }
+                    anyhow::bail!("compilation failed with {} error(s)", diags.len())
+                }
+            }
+        }
+    }
+}

--- a/crates/skroll-lang/src/lib.rs
+++ b/crates/skroll-lang/src/lib.rs
@@ -1,0 +1,34 @@
+//! Compiler front-end crate.
+//! For Task 1 we provide a minimal placeholder compile function that returns a valid StoryDoc.
+
+use skroll_schema::StoryDoc;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CompileError {
+    #[error("io error: {0}")]
+    Io(std::io::Error),
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    pub message: String,
+    pub span: Option<Span>,
+}
+
+pub type Diagnostics = Vec<Diagnostic>;
+
+/// Placeholder compile step: emit a minimal StoryDoc with entry "start".
+/// Next tasks will parse and validate the actual `.skr` source.
+pub fn compile_to_document(_source: &str) -> Result<StoryDoc, Diagnostics> {
+    let doc = StoryDoc::empty_with_entry("start");
+    Ok(doc)
+}

--- a/crates/skroll-lang/tests/smoke.rs
+++ b/crates/skroll-lang/tests/smoke.rs
@@ -1,0 +1,7 @@
+#[test]
+fn cli_wire_works() {
+    let doc = skroll_lang::compile_to_document("=== start ===\nHello");
+    assert!(doc.is_ok());
+    let json = serde_json::to_string(&doc.unwrap()).unwrap();
+    assert!(json.contains("\"schema_version\""));
+}

--- a/crates/skroll-schema/Cargo.toml
+++ b/crates/skroll-schema/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "skroll-schema"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/skroll-schema/src/lib.rs
+++ b/crates/skroll-schema/src/lib.rs
@@ -1,0 +1,51 @@
+//! Versioned JSON document types emitted by the compiler.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const SCHEMA_VERSION: &str = "1.0.0";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoryDoc {
+    pub schema_version: String,
+    #[serde(rename = "$schema")]
+    pub schema_url: String,
+    pub entry: String,
+    pub variables: BTreeMap<String, ValueDoc>,
+    pub nodes: Vec<StoryNodeDoc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "t", content = "v")]
+pub enum ValueDoc {
+    Bool(bool),
+    Int(i64),
+    Str(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StoryNodeDoc {
+    pub id: String,
+    pub lines: Vec<String>,
+    pub choices: Vec<ChoiceDoc>,
+    pub divert: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ChoiceDoc {
+    pub text: String,
+    pub condition: Option<String>,
+    pub target: String,
+}
+
+impl StoryDoc {
+    pub fn empty_with_entry(entry: impl Into<String>) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION.to_string(),
+            schema_url: "https://example.com/schemas/skroll-story-1.0.0.json".to_string(),
+            entry: entry.into(),
+            variables: BTreeMap::new(),
+            nodes: Vec::new(),
+        }
+    }
+}

--- a/examples/hello.skr
+++ b/examples/hello.skr
@@ -1,0 +1,3 @@
+=== start ===
+Hello, Skroll!
+* Continue -> end

--- a/schemas/skroll-story-1.0.0.schema.json
+++ b/schemas/skroll-story-1.0.0.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Skroll Story",
+  "type": "object",
+  "required": ["schema_version", "entry", "nodes"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "$schema": { "type": "string" },
+    "entry": { "type": "string" },
+    "variables": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "number" },
+          { "type": "boolean" }
+        ]
+      }
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string" },
+          "lines": { "type": "array", "items": { "type": "string" } },
+          "choices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["text", "target"],
+              "properties": {
+                "text": { "type": "string" },
+                "condition": { "type": "string" },
+                "target": { "type": "string" }
+              }
+            }
+          },
+          "divert": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add skroll-schema and skroll-lang crates to the Rust workspace
- implement a placeholder compiler API and `skrollc` CLI that emits a minimal story document
- provide example source, draft schema, documentation updates, and CI workflow covering the workspace

## Testing
- cargo fmt *(fails: rustfmt component cannot be downloaded in the sandbox)*
- cargo build *(fails: crates.io index cannot be reached in the sandbox)*
- cargo test *(fails: crates.io index cannot be reached in the sandbox)*
- cargo run -p skroll-lang -- compile examples/hello.skr -o examples/hello.story.json *(fails: crates.io index cannot be reached in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c638a078832ead6b69c39204254b