### PR TITLE
chore: scaffold DSL packages

### DIFF
--- a/packages/engine-skroll/package.json
+++ b/packages/engine-skroll/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@skroll/engine-skroll",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.ts\""
+  }
+}

--- a/packages/engine-skroll/src/index.ts
+++ b/packages/engine-skroll/src/index.ts
@@ -1,0 +1,2 @@
+// Placeholder entrypoint for the Skroll DSL engine package.
+export {};

--- a/packages/engine-skroll/tsconfig.json
+++ b/packages/engine-skroll/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../parser-skroll" }
+  ]
+}

--- a/packages/grammar-skroll/package.json
+++ b/packages/grammar-skroll/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@skroll/grammar-skroll",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.ts\""
+  }
+}

--- a/packages/grammar-skroll/src/index.ts
+++ b/packages/grammar-skroll/src/index.ts
@@ -1,0 +1,2 @@
+// Placeholder entrypoint for the Skroll DSL grammar package.
+export {};

--- a/packages/grammar-skroll/tsconfig.json
+++ b/packages/grammar-skroll/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/parser-skroll/package.json
+++ b/packages/parser-skroll/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@skroll/parser-skroll",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.ts\""
+  }
+}

--- a/packages/parser-skroll/src/index.ts
+++ b/packages/parser-skroll/src/index.ts
@@ -1,0 +1,2 @@
+// Placeholder entrypoint for the Skroll DSL parser package.
+export {};

--- a/packages/parser-skroll/tsconfig.json
+++ b/packages/parser-skroll/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../grammar-skroll" }
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,10 @@
     "paths": {
       "@skroll/ipc-contracts": ["packages/ipc-contracts/src"],
       "@skroll/story-engine": ["packages/story-engine/src"],
-      "@skroll/storage": ["packages/storage/src"]
+      "@skroll/storage": ["packages/storage/src"],
+      "@skroll/grammar-skroll": ["packages/grammar-skroll/src"],
+      "@skroll/parser-skroll": ["packages/parser-skroll/src"],
+      "@skroll/engine-skroll": ["packages/engine-skroll/src"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add initial empty packages for the DSL grammar, parser, and engine
- wire new packages into the shared TypeScript path aliases

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6f02444d4832ebc009b9e0a779ccc