### PR TITLE
feat: scaffold parser runtime for Skroll DSL

### DIFF
--- a/packages/parser-skroll/package.json
+++ b/packages/parser-skroll/package.json
@@ -8,5 +8,9 @@
     "build": "tsc -b",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "@skroll/tree-sitter-skroll": "workspace:*",
+    "tree-sitter": "0.25.0"
   }
 }

--- a/packages/parser-skroll/src/index.ts
+++ b/packages/parser-skroll/src/index.ts
@@ -1,2 +1,267 @@
-// Placeholder entrypoint for the Skroll DSL parser package.
-export {};
+import Parser from "tree-sitter";
+import { createParser } from "@skroll/tree-sitter-skroll";
+
+const parserInstance: Parser = createParser();
+
+export type DiagnosticSeverity = "error" | "warning" | "info";
+
+export interface SourcePosition {
+  /** Zero-based character offset from the start of the script. */
+  offset: number;
+  /** One-based line number. */
+  line: number;
+  /** One-based column number. */
+  column: number;
+}
+
+export interface SourceRange {
+  start: SourcePosition;
+  end: SourcePosition;
+}
+
+export interface Diagnostic {
+  code: string;
+  message: string;
+  severity: DiagnosticSeverity;
+  range: SourceRange;
+}
+
+export type NodeKind = "story" | "scene" | "beat" | "choice" | "config" | "unknown";
+
+export interface Choice {
+  label: string;
+  target?: string;
+  when?: string;
+  body?: string;
+  range: SourceRange;
+}
+
+export interface Node {
+  id: string;
+  kind: NodeKind;
+  when?: string;
+  body: string;
+  range: SourceRange;
+  children: Node[];
+  choices: Choice[];
+}
+
+export interface Script {
+  type: "Script";
+  metadata: Record<string, string>;
+  nodes: Node[];
+  range: SourceRange;
+}
+
+export interface ParseResult {
+  runtime: Script;
+  diagnostics: Diagnostic[];
+}
+
+function toRange(node: Parser.SyntaxNode): SourceRange {
+  return {
+    start: {
+      offset: node.startIndex,
+      line: node.startPosition.row + 1,
+      column: node.startPosition.column + 1,
+    },
+    end: {
+      offset: node.endIndex,
+      line: node.endPosition.row + 1,
+      column: node.endPosition.column + 1,
+    },
+  };
+}
+
+function extractText(source: string, start: number, end: number): string {
+  return source.slice(start, end);
+}
+
+function unquote(value: string): string {
+  if (value.length >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function blockBody(node: Parser.SyntaxNode, source: string): string {
+  const blockStart = node.children.find((child) => child.type === "block_start");
+  const blockEnd = [...node.children].reverse().find((child) => child.type === "block_end");
+  if (!blockStart || !blockEnd) {
+    return "";
+  }
+  return extractText(source, blockStart.endIndex, blockEnd.startIndex).trim();
+}
+
+function findWhenClause(node: Parser.SyntaxNode): string | undefined {
+  const clause = node.namedChildren.find((child) => child.type === "when_clause");
+  if (!clause) {
+    return undefined;
+  }
+  const condition = clause.childForFieldName("condition");
+  return condition ? condition.text.trim() : undefined;
+}
+
+function parseChoiceBlock(node: Parser.SyntaxNode, source: string): Choice[] {
+  const blockCondition = findWhenClause(node);
+  const choices: Choice[] = [];
+  for (const child of node.namedChildren) {
+    if (child.type !== "option_entry") {
+      continue;
+    }
+    const labelNode = child.childForFieldName("label") ?? child.namedChildren.find((c) => c.type === "string");
+    if (!labelNode) {
+      continue;
+    }
+    const optionCondition = findWhenClause(child);
+    const targetNode = child.childForFieldName("target");
+    const blockStart = child.children.find((c) => c.type === "block_start");
+    const blockEnd = [...child.children].reverse().find((c) => c.type === "block_end");
+    let body: string | undefined;
+    if (blockStart && blockEnd) {
+      body = extractText(source, blockStart.endIndex, blockEnd.startIndex).trim();
+    }
+    const conditions = [blockCondition, optionCondition].filter(Boolean);
+    choices.push({
+      label: unquote(labelNode.text),
+      target: targetNode?.text.trim(),
+      when: conditions.length ? conditions.join(" and ") : undefined,
+      body: body && body.length > 0 ? body : undefined,
+      range: toRange(child),
+    });
+  }
+  return choices;
+}
+
+function toKind(type: string): NodeKind {
+  switch (type) {
+    case "story_declaration":
+      return "story";
+    case "scene_declaration":
+      return "scene";
+    case "beat_declaration":
+      return "beat";
+    case "choice_block":
+      return "choice";
+    case "config_block":
+      return "config";
+    default:
+      return "unknown";
+  }
+}
+
+function buildNode(node: Parser.SyntaxNode, source: string): Node {
+  const idNode = node.childForFieldName("name");
+  const id = idNode ? idNode.text : "";
+  const when = findWhenClause(node);
+  const children: Node[] = [];
+  const choices: Choice[] = [];
+
+  for (const child of node.namedChildren) {
+    switch (child.type) {
+      case "scene_declaration":
+      case "beat_declaration":
+        children.push(buildNode(child, source));
+        break;
+      case "choice_block":
+        choices.push(...parseChoiceBlock(child, source));
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {
+    id,
+    kind: toKind(node.type),
+    when,
+    body: blockBody(node, source),
+    range: toRange(node),
+    children,
+    choices,
+  };
+}
+
+function parseMetadata(root: Parser.SyntaxNode, source: string): Record<string, string> {
+  const metadataNode = root.namedChildren.find((child) => child.type === "metadata_fence");
+  if (!metadataNode) {
+    return {};
+  }
+  const metadata: Record<string, string> = {};
+  for (const entry of metadataNode.namedChildren) {
+    if (entry.type !== "metadata_entry") {
+      continue;
+    }
+    const keyNode = entry.childForFieldName("key");
+    if (!keyNode) {
+      continue;
+    }
+    const valueNode = entry.childForFieldName("value");
+    const rawValue = valueNode ? extractText(source, valueNode.startIndex, valueNode.endIndex).trim() : "";
+    metadata[keyNode.text] = valueNode?.type === "string" ? unquote(valueNode.text) : rawValue;
+  }
+  return metadata;
+}
+
+function buildScript(root: Parser.SyntaxNode, source: string): Script {
+  const metadata = parseMetadata(root, source);
+  const nodes: Node[] = [];
+  for (const child of root.namedChildren) {
+    if (child.type === "story_declaration" || child.type === "scene_declaration" || child.type === "beat_declaration") {
+      nodes.push(buildNode(child, source));
+    }
+  }
+  return {
+    type: "Script",
+    metadata,
+    nodes,
+    range: toRange(root),
+  };
+}
+
+function collectDiagnostics(root: Parser.SyntaxNode, source: string): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const stack: Parser.SyntaxNode[] = [root];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.type === "ERROR") {
+      const snippet = extractText(source, current.startIndex, current.endIndex).trim();
+      diagnostics.push({
+        code: "SKR001",
+        message: snippet.length ? `Unexpected token near \"${snippet}\".` : "Unexpected token.",
+        severity: "error",
+        range: toRange(current),
+      });
+    }
+    if (current.isMissing) {
+      diagnostics.push({
+        code: "SKR002",
+        message: `Missing ${current.type.toLowerCase()} segment.`,
+        severity: "error",
+        range: toRange(current),
+      });
+    }
+    if (current.type === "inconsistent_indentation") {
+      diagnostics.push({
+        code: "SKR003",
+        message: "Inconsistent indentation detected.",
+        severity: "error",
+        range: toRange(current),
+      });
+    }
+    for (const child of current.children) {
+      stack.push(child);
+    }
+  }
+  return diagnostics;
+}
+
+export function parse(script: string): ParseResult {
+  const tree = parserInstance.parse(script);
+  return {
+    runtime: buildScript(tree.rootNode, script),
+    diagnostics: collectDiagnostics(tree.rootNode, script),
+  };
+}
+
+export { getLanguage } from "@skroll/tree-sitter-skroll";

--- a/packages/tree-sitter-skroll/binding.gyp
+++ b/packages/tree-sitter-skroll/binding.gyp
@@ -2,13 +2,22 @@
   "targets": [
     {
       "target_name": "tree_sitter_skroll_binding",
-        "sources": [
-          "src/parser.c",
-          "src/scanner.c"
-        ],
+      "sources": [
+        "bindings/node/binding.cc",
+        "src/parser.c",
+        "src/scanner.c"
+      ],
+      "include_dirs": [
+        "src",
+        "<!(node -p \"require('node-addon-api').include_dir\")"
+      ],
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').gyp\")"
+      ],
+      "defines": ["NAPI_CPP_EXCEPTIONS"],
       "cflags_c": ["-std=c11"],
       "cflags_cc": ["-std=c++17"],
-      "include_dirs": ["src"]
+      "cflags_cc!": ["-fno-exceptions", "-fno-rtti"]
     }
   ]
 }

--- a/packages/tree-sitter-skroll/bindings/node/binding.cc
+++ b/packages/tree-sitter-skroll/bindings/node/binding.cc
@@ -1,0 +1,20 @@
+#include <napi.h>
+
+typedef struct TSLanguage TSLanguage;
+
+extern "C" TSLanguage *tree_sitter_skroll();
+
+// "tree-sitter", "language" hashed with BLAKE2
+const napi_type_tag LANGUAGE_TYPE_TAG = {
+  0x8AF2E5212AD58ABF, 0xD5006CAD83ABBA16
+};
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    exports["name"] = Napi::String::New(env, "skroll");
+    auto language = Napi::External<TSLanguage>::New(env, tree_sitter_skroll());
+    language.TypeTag(&LANGUAGE_TYPE_TAG);
+    exports["language"] = language;
+    return exports;
+}
+
+NODE_API_MODULE(tree_sitter_skroll_binding, Init)

--- a/packages/tree-sitter-skroll/bindings/node/index.d.ts
+++ b/packages/tree-sitter-skroll/bindings/node/index.d.ts
@@ -1,0 +1,28 @@
+type BaseNode = {
+  type: string;
+  named: boolean;
+};
+
+type ChildNode = {
+  multiple: boolean;
+  required: boolean;
+  types: BaseNode[];
+};
+
+type NodeInfo =
+  | (BaseNode & {
+      subtypes: BaseNode[];
+    })
+  | (BaseNode & {
+      fields: { [name: string]: ChildNode };
+      children: ChildNode[];
+    });
+
+type Language = {
+  name: string;
+  language: unknown;
+  nodeTypeInfo: NodeInfo[];
+};
+
+declare const language: Language;
+export = language;

--- a/packages/tree-sitter-skroll/bindings/node/index.js
+++ b/packages/tree-sitter-skroll/bindings/node/index.js
@@ -1,0 +1,7 @@
+const root = require("path").join(__dirname, "..", "..");
+
+module.exports = require("node-gyp-build")(root);
+
+try {
+  module.exports.nodeTypeInfo = require("../../src/node-types.json");
+} catch (_) {}

--- a/packages/tree-sitter-skroll/package.json
+++ b/packages/tree-sitter-skroll/package.json
@@ -6,16 +6,36 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf build tree-sitter-skroll.wasm skroll.dylib skroll.dylib.dSYM",
-    "build": "pnpm run gen && tsc -b",
-    "gen": "tree-sitter generate --no-bindings",
+    "build": "tsc -b",
+    "gen": "tree-sitter generate",
     "build:native": "pnpm run gen && tree-sitter build",
     "build:wasm": "pnpm run gen && tree-sitter build --wasm --output ./tree-sitter-skroll.wasm",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\"",
+    "install": "node-gyp-build"
+  },
+  "dependencies": {
+    "node-gyp-build": "^4.8.0"
   },
   "devDependencies": {
     "tree-sitter-cli": "0.22.6"
   },
+  "peerDependencies": {
+    "tree-sitter": "^0.25.0"
+  },
+  "peerDependenciesMeta": {
+    "tree-sitter": {
+      "optional": true
+    }
+  },
+  "files": [
+    "grammar.js",
+    "binding.gyp",
+    "prebuilds/**",
+    "bindings/node/*",
+    "queries/*",
+    "src/**"
+  ],
   "tree-sitter": [
     {
       "scope": "source.skroll",

--- a/packages/tree-sitter-skroll/src/index.ts
+++ b/packages/tree-sitter-skroll/src/index.ts
@@ -1,2 +1,24 @@
-// Placeholder entrypoint for the Skroll DSL grammar package.
-export {};
+import Parser from "tree-sitter";
+
+let cachedLanguage: Parser.Language | null = null;
+
+function loadLanguage(): Parser.Language {
+  if (!cachedLanguage) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const binding = require("../bindings/node") as { language: Parser.Language };
+    cachedLanguage = binding.language;
+  }
+  return cachedLanguage;
+}
+
+export function getLanguage(): Parser.Language {
+  return loadLanguage();
+}
+
+export function createParser(): Parser {
+  const parser = new Parser();
+  parser.setLanguage(loadLanguage());
+  return parser;
+}
+
+export type { SyntaxNode } from "tree-sitter";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,7 +151,14 @@ importers:
         specifier: 10.9.2
         version: 10.9.2(@types/node@22.18.6)(typescript@5.9.2)
 
-  packages/parser-skroll: {}
+  packages/parser-skroll:
+    dependencies:
+      '@skroll/tree-sitter-skroll':
+        specifier: workspace:*
+        version: link:../tree-sitter-skroll
+      tree-sitter:
+        specifier: 0.25.0
+        version: 0.25.0
 
   packages/storage: {}
 
@@ -168,6 +175,13 @@ importers:
         version: 29.4.4(@babel/core@7.28.4)(@jest/transform@30.1.2)(@jest/types@30.0.5)(babel-jest@30.1.2(@babel/core@7.28.4))(jest-util@30.0.5)(jest@30.1.3(@types/node@22.18.6)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.18.6)(typescript@5.9.2)))(typescript@5.9.2)
 
   packages/tree-sitter-skroll:
+    dependencies:
+      node-gyp-build:
+        specifier: ^4.8.0
+        version: 4.8.4
+      tree-sitter:
+        specifier: ^0.25.0
+        version: 0.25.0
     devDependencies:
       tree-sitter-cli:
         specifier: 0.22.6
@@ -3446,6 +3460,10 @@ packages:
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
+  node-addon-api@8.5.0:
+    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -3461,6 +3479,10 @@ packages:
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -4452,6 +4474,9 @@ packages:
   tree-sitter-cli@0.22.6:
     resolution: {integrity: sha512-s7mYOJXi8sIFkt/nLJSqlYZP96VmKTc3BAwIX0rrrlRxWjWuCwixFqwzxWZBQz4R8Hx01iP7z3cT3ih58BUmZQ==}
     hasBin: true
+
+  tree-sitter@0.25.0:
+    resolution: {integrity: sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==}
 
   trim-repeated@1.0.0:
     resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
@@ -9208,6 +9233,8 @@ snapshots:
 
   node-abort-controller@3.1.1: {}
 
+  node-addon-api@8.5.0: {}
+
   node-api-version@0.2.1:
     dependencies:
       semver: 7.7.2
@@ -9219,6 +9246,8 @@ snapshots:
       encoding: 0.1.13
 
   node-forge@1.3.1: {}
+
+  node-gyp-build@4.8.4: {}
 
   node-int64@0.4.0: {}
 
@@ -10271,6 +10300,11 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-sitter-cli@0.22.6: {}
+
+  tree-sitter@0.25.0:
+    dependencies:
+      node-addon-api: 8.5.0
+      node-gyp-build: 4.8.4
 
   trim-repeated@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- define Script/Node/Choice/Diagnostic runtime types and expose a parse() entrypoint in @skroll/parser-skroll
- load the Tree-Sitter Skroll grammar via a new language helper and share a configured Parser instance
- include the generated Node bindings and native build configuration for @skroll/tree-sitter-skroll

## Testing
- pnpm --filter @skroll/parser-skroll build
- pnpm --filter @skroll/tree-sitter-skroll build

------
https://chatgpt.com/codex/tasks/task_e_68d84867d038832ea9ba491fa49113d5