### PR TITLE
fix: bundle tree-sitter wasm assets

### DIFF
--- a/apps/desktop/webpack.plugins.ts
+++ b/apps/desktop/webpack.plugins.ts
@@ -1,10 +1,34 @@
+import path from "node:path";
+
+import CopyWebpackPlugin from "copy-webpack-plugin";
 import type IForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 
+const treeSitterWasmAssets = [
+  {
+    from: path.resolve(
+      __dirname,
+      "src",
+      "shared",
+      "tree-sitter-skroll",
+      "tree-sitter-skroll.wasm",
+    ),
+    to: path.join("tree-sitter", "[name][ext]"),
+    noErrorOnMissing: true,
+  },
+  {
+    from: path.resolve(__dirname, "../../node_modules/web-tree-sitter/tree-sitter.wasm"),
+    to: path.join("tree-sitter", "[name][ext]"),
+  },
+];
+
 export const plugins = [
   new ForkTsCheckerWebpackPlugin({
     logger: "webpack-infrastructure",
+  }),
+  new CopyWebpackPlugin({
+    patterns: treeSitterWasmAssets,
   }),
 ];

--- a/apps/desktop/webpack.rules.ts
+++ b/apps/desktop/webpack.rules.ts
@@ -31,5 +31,8 @@ export const rules: Required<ModuleOptions>["rules"] = [
   {
     test: /\.wasm$/,
     type: "asset/resource",
+    generator: {
+      filename: "tree-sitter/[name][ext]",
+    },
   },
 ];


### PR DESCRIPTION
## Summary
- copy the core and grammar Tree-sitter WASM files during webpack builds
- ensure emitted WASM assets land in a stable tree-sitter/ directory for runtime lookup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e81aac1ff4832e99f4fd88eea16c77